### PR TITLE
Fix the terraform plan → apply check

### DIFF
--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -27,9 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: hashicorp/setup-terraform@v3
+      - name: Install latest terraform version
+        uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.9.1"
+          # We do not want the terraform wrapper that is masking the terraform plan -detailed-exitcode.
+          terraform_wrapper: false
 
       # Initialize a new or existing Terraform working directory by creating initial files,
       # loading any remote state, downloading modules, etc.
@@ -119,7 +121,7 @@ jobs:
 
   terraform-apply:
     name: 'Terraform Apply'
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.terraform-plan.outputs.tfplanExitCode == 2
     runs-on: ubuntu-latest
     needs: [terraform-plan]
 
@@ -128,9 +130,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: hashicorp/setup-terraform@v3
+      - name: Install latest terraform version
+        uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.9.1"
+          # We do not want the terraform wrapper. Too much magic.
+          terraform_wrapper: false
 
       # Initialize a new or existing Terraform working directory by creating initial files,
       # loading any remote state, downloading modules, etc.

--- a/provider.tf
+++ b/provider.tf
@@ -6,9 +6,9 @@ terraform {
   }
 
   backend "http" {
-    address        = "https://psumac24-south-carolina.zentral.cloud/api/terraform/backend/starter_kit/"
-    lock_address   = "https://psumac24-south-carolina.zentral.cloud/api/terraform/backend/starter_kit/lock/"
-    unlock_address = "https://psumac24-south-carolina.zentral.cloud/api/terraform/backend/starter_kit/lock/"
+    address        = "https://psumac24-north-dakota.zentral.cloud/api/terraform/backend/starter_kit/"
+    lock_address   = "https://psumac24-north-dakota.zentral.cloud/api/terraform/backend/starter_kit/lock/"
+    unlock_address = "https://psumac24-north-dakota.zentral.cloud/api/terraform/backend/starter_kit/lock/"
     lock_method    = "POST"
     unlock_method  = "DELETE"
   }


### PR DESCRIPTION
We do not use the Terraform setup action wrapper. It will expose terraform directly. This fixes the exit code check (2 for changes).